### PR TITLE
Corregir renderizado del formulario al crear nuevo invitado en GuestModal

### DIFF
--- a/src/views/GuestView/GuestViewComponents/GuestModal.jsx
+++ b/src/views/GuestView/GuestViewComponents/GuestModal.jsx
@@ -40,12 +40,32 @@ const GuestModal = ({
   const [localGuest, setLocalGuest] = useState(null);
 
   useEffect(() => {
-    if (open && guest) {
-      setLocalGuest({
-        ...guest,
-        plus_ones: guest.plus_ones || [],
-      });
-    } else if (open) {
+    if (open) {
+      if (guest) {
+        setLocalGuest({
+          ...guest,
+          plus_ones: guest.plus_ones || [],
+        });
+      } else {
+        // Initialize an empty guest object for new guest creation
+        setLocalGuest({
+          first_name: "",
+          last_name: "",
+          phone: "",
+          email: "",
+          needs_transport: false,
+          needs_transport_back: false,
+          needs_hotel: false,
+          disability: false,
+          menu_id: null,
+          observations: "",
+          accommodation_plan: "",
+          plus_ones: [],
+          tags: [],
+          allergies: [],
+        });
+      }
+    } else {
       setLocalGuest(null);
     }
   }, [open, guest]);
@@ -137,7 +157,7 @@ const GuestModal = ({
         <CloseButton onClose={onClose} />
       </DialogTitle>
       <DialogContent>
-        {localGuest !== null && (
+        {localGuest && (
           <GuestForm
             guest={localGuest}
             onSubmit={handleSubmit}
@@ -173,6 +193,7 @@ const GuestModal = ({
     </Dialog>
   );
 };
+
 GuestModal.propTypes = {
   open: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
@@ -207,19 +228,7 @@ GuestModal.propTypes = {
       name: PropTypes.string.isRequired,
     })
   ).isRequired,
-  allergies: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.number.isRequired,
-      name: PropTypes.string.isRequired,
-    })
-  ).isRequired,
   allAllergies: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.number.isRequired,
-      name: PropTypes.string.isRequired,
-    })
-  ).isRequired,
-  tags: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.number.isRequired,
       name: PropTypes.string.isRequired,
@@ -246,6 +255,7 @@ GuestModal.propTypes = {
     tags: PropTypes.bool,
     plus_ones: PropTypes.bool,
   }).isRequired,
+  onOpenTagModal: PropTypes.func.isRequired,
 };
 
 export default GuestModal;


### PR DESCRIPTION
## Descripción del problema
Al intentar abrir el modal de GuestModal desde el botón para crear un nuevo invitado, los campos del formulario no se renderizaban correctamente. Esto impedía a los usuarios crear nuevos invitados de manera efectiva.

## Solución implementada
Se ha modificado el componente GuestModal para asegurar que el formulario se renderice correctamente tanto para la creación de nuevos invitados como para la edición de invitados existentes. Los cambios principales incluyen:

1. Inicialización de un objeto invitado vacío cuando se está creando un nuevo invitado.
2. Renderizado del GuestForm siempre que localGuest tenga un valor.
3. Reinicio de localGuest a null cuando se cierra el modal.
4. Actualización del useEffect para manejar tanto escenarios de edición como de creación.

## Cambios realizados
- Se modificó el `useEffect` en GuestModal para inicializar un objeto invitado vacío cuando se crea un nuevo invitado.
- Se cambió la condición de renderizado del GuestForm para que se muestre siempre que localGuest tenga un valor.
- Se agregó lógica para reiniciar localGuest a null cuando el modal se cierra.
- Se actualizaron los PropTypes para reflejar los cambios en la estructura de datos.

## Cómo probar
1. Abrir la vista de invitados.
2. Hacer clic en el botón "Crear Nuevo Invitado".
3. Verificar que todos los campos del formulario se rendericen correctamente.
4. Intentar crear un nuevo invitado y asegurarse de que se guarde correctamente.
5. Editar un invitado existente y confirmar que los datos se cargan y se pueden modificar correctamente.

## Notas adicionales
- Este cambio no afecta la funcionalidad existente para editar invitados.
- Se han mantenido todas las validaciones y manejo de errores existentes.

